### PR TITLE
Modified KWIC search to include title page.

### DIFF
--- a/eXist-dbs/salmer/xqueries/kwic_search.xquery
+++ b/eXist-dbs/salmer/xqueries/kwic_search.xquery
@@ -15,11 +15,14 @@ let $q := request:get-parameter('q', '')
 let $coll := collection("/db/apps/salmer/xml")/tei:TEI/tei:text
 
 (: Here, generate results for front and back matter :)
-let $front_hits := $coll/tei:front/tei:div[ft:query(., $q)]
+let $front_hits := $coll/tei:front/*[ft:query(., $q)]
 let $back_hits := $coll/tei:back/tei:div[ft:query(., $q)]
+
 
 let $front_results := for $hit in $front_hits
     let $page_no := util:expand($hit, "expand-xincludes=no highlight-matches=both")//exist:match/preceding::tei:pb[1]/string(@n)
+    let $title := $hit/ancestor::*//tei:titleStmt/tei:title/text()
+    where ($title)
     order by ft:score($hit) descending
         return
     <result_list>
@@ -70,4 +73,4 @@ return
        {$front_results}
        {$body_results}
        {$back_results}
-   </results>
+    </results>

--- a/eXist-dbs/salmer/xqueries/kwic_search.xquery
+++ b/eXist-dbs/salmer/xqueries/kwic_search.xquery
@@ -15,14 +15,28 @@ let $q := request:get-parameter('q', '')
 let $coll := collection("/db/apps/salmer/xml")/tei:TEI/tei:text
 
 (: Here, generate results for front and back matter :)
-let $front_hits := $coll/tei:front/*[ft:query(., $q)]
+
+
+let $title_hits := $coll/tei:front/tei:titlePage[ft:query(., $q)]
+let $front_hits := $coll/tei:front/tei:div[ft:query(., $q)]
 let $back_hits := $coll/tei:back/tei:div[ft:query(., $q)]
 
+let $title_results := for $hit in $title_hits
+    let $page_no := util:expand($hit, "expand-xincludes=no highlight-matches=both")//exist:match/preceding::tei:pb[1]/string(@n)
+    order by ft:score($hit) descending
+        return
+    <result_list>
+        <page_no>{$page_no}</page_no>
+        <chapter_no>front</chapter_no>
+        <section_no>{count($hit/tei:div[ft:query(., $q)]/preceding-sibling::tei:div) +1}</section_no>
+        <id>{util:document-name($hit)}</id>
+        <title>{$hit/ancestor::*//tei:titleStmt/tei:title/text()}</title>
+        <q>{$q}</q>
+        <kwic>{kwic:summarize($hit, <config width="40"/>)}</kwic>
+    </result_list>
 
 let $front_results := for $hit in $front_hits
     let $page_no := util:expand($hit, "expand-xincludes=no highlight-matches=both")//exist:match/preceding::tei:pb[1]/string(@n)
-    let $title := $hit/ancestor::*//tei:titleStmt/tei:title/text()
-    where ($title)
     order by ft:score($hit) descending
         return
     <result_list>
@@ -66,10 +80,11 @@ let $body_results := for $hit in $body_hits
         <kwic>{kwic:summarize($hit, <config width="40"/>)}</kwic>
     </result_list>
     
-let $count := count($body_results) + count($front_results) + count($back_results)
+let $count := count($body_results) + count($title_results) + count($front_results) + count($back_results)
 return    
    <results>
        <no_of_results>{$count}</no_of_results>
+       {$title_results}
        {$front_results}
        {$body_results}
        {$back_results}


### PR DESCRIPTION
This is a small fix to include hits in other sections than the main `tei:div`, including the title page section.

This includes matter only present on title pages, e.g. "wddragne", in the search results.

The results are presented with the entire front section as _one_ section, as is already the case with search hits in one of the front sections proper (excluding the title page), as seen e.g. when searching for "vwitterligt".