### PR TITLE
Correct display of results in /front and /back

### DIFF
--- a/eXist-dbs/salmer/xqueries/kwic_search.xquery
+++ b/eXist-dbs/salmer/xqueries/kwic_search.xquery
@@ -27,7 +27,7 @@ let $title_results := for $hit in $title_hits
         return
     <result_list>
         <page_no>{$page_no}</page_no>
-        <chapter_no>front</chapter_no>
+        <chapter_no>titelblad</chapter_no>
         <section_no>{count($hit/tei:div[ft:query(., $q)]/preceding-sibling::tei:div) +1}</section_no>
         <id>{util:document-name($hit)}</id>
         <title>{$hit/ancestor::*//tei:titleStmt/tei:title/text()}</title>

--- a/eXist-dbs/salmer/xqueries/two_level_kwic.xquery
+++ b/eXist-dbs/salmer/xqueries/two_level_kwic.xquery
@@ -27,7 +27,7 @@ let $title_results := for $hit in $title_hits
         return
     <result_list>
         <page_no>{$page_no}</page_no>
-        <chapter_no>front</chapter_no>
+        <chapter_no>titelblad</chapter_no>
         <section_no>{count($hit/tei:div[ft:query(., $q)]/preceding-sibling::tei:div) +1}</section_no>
         <id>{util:document-name($hit)}</id>
         <title>{$hit/ancestor::*//tei:titleStmt/tei:title/text()}</title>

--- a/generic_literature_site/generic_literature_site/views.py
+++ b/generic_literature_site/generic_literature_site/views.py
@@ -1461,7 +1461,8 @@ def process_search_results(search_result, document_ids, request):
             sections = get_sections(
                 xquery_folder, id_with_xml, i["chapter_no"]
             )
-            if not sections:
+            # import pdb; pdb.set_trace()
+            if not (sections or i["chapter_no"] in ["back", "front"]):
                 i["section_no"] = ""
 
             kwic_lines = format_kwic_lines(i)


### PR DESCRIPTION
This corrects the title page view when accessing a search result in /front or /back, including the title page.